### PR TITLE
fix: API calls when using custom base URL

### DIFF
--- a/saagie-zeppelin-config.sh
+++ b/saagie-zeppelin-config.sh
@@ -25,8 +25,6 @@ then
   then
     ZEPPELIN_SERVER_CONTEXT_PATH=''
   fi
-  echo "DEBUG: sending the following JSON to http://localhost:$PORT0$ZEPPELIN_SERVER_CONTEXT_PATH/api/interpreter/setting/$interpreterId :"
-  echo "$json"
   curl -v -X PUT -H "Content-Type: application/json" -d "$json" "http://localhost:$PORT0$ZEPPELIN_SERVER_CONTEXT_PATH/api/interpreter/setting/$interpreterId"
 
 else

--- a/saagie-zeppelin-config.sh
+++ b/saagie-zeppelin-config.sh
@@ -20,7 +20,15 @@ then
   # build the JSON to send to Zeppelin API to update the Spark interpreter config
   json="{\"option\":$updatedOption, \"properties\":$properties, \"dependencies:\":$dependencies}"
 
-  curl -X PUT -H "Content-Type: application/json" -d "$json" "http://localhost:$PORT0/api/interpreter/setting/$interpreterId"
+  # Use notebook base url (if it has been changed) when requesting its API.
+  if [ -z $ZEPPELIN_SERVER_CONTEXT_PATH ]
+  then
+    ZEPPELIN_SERVER_CONTEXT_PATH=''
+  fi
+  echo "DEBUG: sending the following JSON to http://localhost:$PORT0$ZEPPELIN_SERVER_CONTEXT_PATH/api/interpreter/setting/$interpreterId :"
+  echo "$json"
+  curl -v -X PUT -H "Content-Type: application/json" -d "$json" "http://localhost:$PORT0$ZEPPELIN_SERVER_CONTEXT_PATH/api/interpreter/setting/$interpreterId"
+
 else
   echo "WARNING: no Interpreter config found. Zeppelin interpreters will run with default config."
 fi


### PR DESCRIPTION
As we are using Zeppelin API to upgrade the Spark Interpreter config (to set it in "Per Note / Isolated" mode), we need to change the API URLs when using a custom base URL (when  `ZEPPELIN_SERVER_CONTEXT_PATH` envvar is set to something other than `/`).