### PR TITLE
Feat/persist interpreter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ RUN apt-get update
 RUN apt-get -y install vim
 
 # Add CRON to copy interpreter.json to persisted folder
-RUN (crontab -l && echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/") | crontab -
+RUN echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/" >> mycron && \
+crontab mycron && \
+rm mycron
 
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update
 RUN apt-get -y install vim
 
 # Add CRON to copy interpreter.json to persisted folder
-RUN crontab < <(crontab -l ; echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/")
+RUN (crontab -l && echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/") | crontab -
 
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,12 @@ RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh
 # Set Saagie's cluster Java version
 ENV JAVA_VERSION 8.131
 
+# Install vim
+RUN apt-get update
+RUN apt-get -y install vim
+
+# Add CRON to copy interpreter.json to persisted folder
+RUN crontab < <(crontab -l ; echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/")
+
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/saagie-zeppelin.sh
+++ b/saagie-zeppelin.sh
@@ -91,6 +91,9 @@ then
   cp -f /notebook/interpreter.json /zeppelin/conf/interpreter.json
 fi
 
+#Launch cron
+cron
+
 # Run Zeppelin
 echo "Running Apache Zeppelin..."
 /zeppelin/bin/zeppelin.sh

--- a/saagie-zeppelin.sh
+++ b/saagie-zeppelin.sh
@@ -85,6 +85,12 @@ fi
 # Run another script to upgrade Spark interpreter config after Zeppelin boot
 /zeppelin/saagie-zeppelin-config.sh &
 
+# Copy interpreter.json from persisted folder if exists
+if [ -f "/notebook/interpreter.json" ]
+then
+  cp -f /notebook/interpreter.json /zeppelin/conf/interpreter.json
+fi
+
 # Run Zeppelin
 echo "Running Apache Zeppelin..."
 /zeppelin/bin/zeppelin.sh


### PR DESCRIPTION
Copy regulary with CRON of file /zeppelin/conf/interpreter.json to /notebook/ to persist this file. At reboot of the notebook this file is copied at the original place. The aim is to persist interpreters *.