### PR TITLE
Upgrade zeppelin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,11 @@ ENV JAVA_VERSION 8.131
 RUN apt-get update
 RUN apt-get -y install vim
 
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update -qq && apt install -yqq --no-install-recommends \
+      krb5-user && \
+    rm -rf /var/lib/apt/lists/*;
+
 # Add CRON to copy interpreter.json to persisted folder
 RUN echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/" >> mycron && \
 crontab mycron && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,67 +1,81 @@
-FROM apache/zeppelin:0.8.1
+FROM apache/zeppelin:0.9.0
 
 MAINTAINER Saagie
 
-# Install Spark 2.3.4
-RUN cd /tmp && wget https://archive.apache.org/dist/spark/spark-2.3.4/spark-2.3.4-bin-hadoop2.6.tgz -O /tmp/spark-2.3.4-bin-hadoop2.6.tgz
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN cd /tmp && tar -xzf spark-2.3.4-bin-hadoop2.6.tgz && \
-  cp spark-2.3.4-bin-hadoop2.6/conf/log4j.properties.template spark-2.3.4-bin-hadoop2.6/conf/log4j.properties && \
-  mkdir -p /usr/local/spark/2.3.4 && mv spark-2.3.4-bin-hadoop2.6/* /usr/local/spark/2.3.4 && \
-  rm -rf spark-2.3.4-bin-hadoop2.6.tgz spark-2.3.4-bin-hadoop2.6
+ENV JAVA_VERSION 8.131
+ENV SPARK_VERSION 2.4.5
+ENV HADOOP_VERSION 2.6
+ENV MESOS_VERSION 1.3.1
+ENV MESOS_VERSION2 2.0.1
 
-# Install Mesos 1.3.1
+ENV HADOOP_HOME /etc/hadoop
+ENV HADOOP_CONF_DIR /etc/hadoop/conf
+ENV SPARK_HOME /usr/local/spark/${SPARK_VERSION}
+
+ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos-${MESOS_VERSION}.so
+
+ENV ZEPPELIN_NOTEBOOK_DIR '/notebook'
+ENV ZEPPELIN_INTP_CLASSPATH_OVERRIDES /etc/hive/conf
+
+
+########################## LIBS PART BEGIN ##########################
+USER root
+# FIXME Remove once apache/zeppelin image will include PR :
+# https://github.com/apache/zeppelin/pull/3755
+# correcting issue :  https://issues.apache.org/jira/browse/ZEPPELIN-4783
+# and once docker image will be rebuild
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9 && \
+    apt-get update -qq && apt-get install -yqq --no-install-recommends \
+      jq \
+      vim \
+    && rm -rf /var/lib/apt/lists/*
+########################## LIBS PART END ##########################
+
+
+########################## Install Spark BEGIN ##########################
+RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -P /tmp \
+    && tar -zxf /tmp/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -C /usr/local/  \
+    && cp /usr/local/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}/conf/log4j.properties.template /usr/local/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}/conf/log4j.properties \
+    && mkdir -p /usr/local/spark \
+    && mv /usr/local/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}/ /usr/local/spark/${SPARK_VERSION} \
+    && rm /tmp/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+########################## Install Spark END ##########################
+
+
+########################## Install MESOS BEGIN ##########################
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]') && \
   CODENAME=$(lsb_release -cs) && \
   echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | tee /etc/apt/sources.list.d/mesosphere.list && \
   apt-get -y update && \
-  apt-get install -y --no-install-recommends mesos=1.3.1-2.0.1
+  apt-get install -y --no-install-recommends \
+    mesos=${MESOS_VERSION}-${MESOS_VERSION2} \
+  && rm -rf /var/lib/apt/lists/*
+########################## Install MESOS END ##########################
 
-# Install jq
-RUN apt-get install -y jq
 
-# Clean
-RUN apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+########################## Install Kerberos Client BEGIN ##########################
+RUN apt update -qq && apt install -yqq --no-install-recommends \
+      krb5-user && \
+    rm -rf /var/lib/apt/lists/*;
+########################## Install Kerberos Client END ##########################
 
-ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos-1.3.1.so
-
-# Set Spark 2.3.4 as the default one
-ENV SPARK_HOME /usr/local/spark/2.3.4
-ENV APACHE_SPARK_VERSION 2.3.4
-
-# Set Hadoop default conf dir
-ENV HADOOP_HOME /etc/hadoop
-ENV HADOOP_CONF_DIR /etc/hadoop/conf
-
-# Set Hive default conf dir
-ENV ZEPPELIN_INTP_CLASSPATH_OVERRIDES /etc/hive/conf
-
-# Default notebooks directory
-ENV ZEPPELIN_NOTEBOOK_DIR '/notebook'
 
 # Add a startup script that will setup Spark conf before running Zeppelin
 ADD saagie-zeppelin.sh /zeppelin
 ADD saagie-zeppelin-config.sh /zeppelin
-RUN chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh
-
-# Set Saagie's cluster Java version
-ENV JAVA_VERSION 8.131
-
-# Install vim
-RUN apt-get update
-RUN apt-get -y install vim
-
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt update -qq && apt install -yqq --no-install-recommends \
-      krb5-user && \
-    rm -rf /var/lib/apt/lists/*;
+RUN chown -R 1000 /zeppelin && chmod 744 /zeppelin/saagie-zeppelin.sh /zeppelin/saagie-zeppelin-config.sh
 
 # Add CRON to copy interpreter.json to persisted folder
 RUN echo "* * * * * cp -f /zeppelin/conf/interpreter.json /notebook/" >> mycron && \
-crontab mycron && \
-rm mycron
+    crontab mycron && \
+    rm mycron
+
+RUN mkdir /notebook && chown -R 1000 /notebook
+
+USER 1000
 
 # Keep default ENTRYPOINT as apache/zeppelin is using Tini, which is great.
 CMD ["/zeppelin/saagie-zeppelin.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM apache/zeppelin:0.8.1
 
 MAINTAINER Saagie
 
-# Install Spark 2.1.0 for Hadoop 2.6
-RUN cd /tmp && wget https://archive.apache.org/dist/spark/spark-2.1.0/spark-2.1.0-bin-hadoop2.6.tgz -O /tmp/spark-2.1.0-bin-hadoop2.6.tgz
+# Install Spark 2.3.4
+RUN cd /tmp && wget https://archive.apache.org/dist/spark/spark-2.3.4/spark-2.3.4-bin-hadoop2.6.tgz -O /tmp/spark-2.3.4-bin-hadoop2.6.tgz
 
-RUN cd /tmp && tar -xzf spark-2.1.0-bin-hadoop2.6.tgz && \
-  cp spark-2.1.0-bin-hadoop2.6/conf/log4j.properties.template spark-2.1.0-bin-hadoop2.6/conf/log4j.properties && \
-  mkdir -p /usr/local/spark/2.1.0 && mv spark-2.1.0-bin-hadoop2.6/* /usr/local/spark/2.1.0 && \
-  rm -rf spark-2.1.0-bin-hadoop2.6.tgz spark-2.1.0-bin-hadoop2.6
+RUN cd /tmp && tar -xzf spark-2.3.4-bin-hadoop2.6.tgz && \
+  cp spark-2.3.4-bin-hadoop2.6/conf/log4j.properties.template spark-2.3.4-bin-hadoop2.6/conf/log4j.properties && \
+  mkdir -p /usr/local/spark/2.3.4 && mv spark-2.3.4-bin-hadoop2.6/* /usr/local/spark/2.3.4 && \
+  rm -rf spark-2.3.4-bin-hadoop2.6.tgz spark-2.3.4-bin-hadoop2.6
 
 # Install Mesos 1.3.1
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
@@ -27,9 +27,9 @@ RUN apt-get clean && \
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos-1.3.1.so
 
-# Set Spark 2.1.0 as the default one
-ENV SPARK_HOME /usr/local/spark/2.1.0
-ENV APACHE_SPARK_VERSION 2.1.0
+# Set Spark 2.3.4 as the default one
+ENV SPARK_HOME /usr/local/spark/2.3.4
+ENV APACHE_SPARK_VERSION 2.3.4
 
 # Set Hadoop default conf dir
 ENV HADOOP_HOME /etc/hadoop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/zeppelin:0.7.3
+FROM apache/zeppelin:0.8.1
 
 MAINTAINER Saagie
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This container can run without any configuration on Saagie's platform.
 
 If you want to run it with an in-memory Spark, just run:
 ```
-docker run -it --rm --name zeppelin -p 8080:8080 saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.3.4
+docker run -it --rm --name zeppelin -p 8080:8080 saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.4.5
 ```
 
  If you want to run it locally but pointing to a remote Spark cluster, run:
@@ -33,7 +33,7 @@ docker run -it --rm --name zeppelin --net=host -e PORT0=[ZEPPELIN_PORT] \
   -v $(pwd)/conf/hadoop/:/etc/hadoop/conf/ \
   -v $(pwd)/conf/spark/spark-env.sh:/usr/local/spark/conf/spark-env.sh \
   -v $(pwd)/conf/spark/spark-defaults.conf:/tmp/spark-defaults.conf \
-  saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.3.4 /zeppelin/saagie-zeppelin.sh -d DEBUG --port [ZEPPELIN_PORT]
+  saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.4.5 /zeppelin/saagie-zeppelin.sh -d DEBUG --port [ZEPPELIN_PORT]
 ```
 
 The given volumes contain Hive, Hadoop, and Spark configuration files of your remote cluster.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This container can run without any configuration on Saagie's platform.
 
 If you want to run it with an in-memory Spark, just run:
 ```
-docker run -it --rm --name zeppelin -p 8080:8080 saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.1.0
+docker run -it --rm --name zeppelin -p 8080:8080 saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.3.4
 ```
 
  If you want to run it locally but pointing to a remote Spark cluster, run:
@@ -33,7 +33,7 @@ docker run -it --rm --name zeppelin --net=host -e PORT0=[ZEPPELIN_PORT] \
   -v $(pwd)/conf/hadoop/:/etc/hadoop/conf/ \
   -v $(pwd)/conf/spark/spark-env.sh:/usr/local/spark/conf/spark-env.sh \
   -v $(pwd)/conf/spark/spark-defaults.conf:/tmp/spark-defaults.conf \
-  saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.1.0 /zeppelin/saagie-zeppelin.sh -d DEBUG --port [ZEPPELIN_PORT]
+  saagie/zeppelin:sp1.12.1-mesos1.3.1-spark2.3.4 /zeppelin/saagie-zeppelin.sh -d DEBUG --port [ZEPPELIN_PORT]
 ```
 
 The given volumes contain Hive, Hadoop, and Spark configuration files of your remote cluster.

--- a/saagie-zeppelin.sh
+++ b/saagie-zeppelin.sh
@@ -54,14 +54,14 @@ fi
 # before running Zepplin
 if [ -f "/usr/local/spark/conf/spark-env.sh" ]
 then
-  # overwrite Spark 2.1.0 config
+  # overwrite Spark 2.3.4 config
   echo "INFO: ovewriting default spark-env.sh"
-  cp /usr/local/spark/conf/spark-env.sh /usr/local/spark/2.1.0/conf
-  chmod 755 /usr/local/spark/2.1.0/conf/spark-env.sh
+  cp /usr/local/spark/conf/spark-env.sh /usr/local/spark/2.3.4/conf
+  chmod 755 /usr/local/spark/2.3.4/conf/spark-env.sh
 else
   # use default config
   echo "WARNING: NO CUSTOM spark-env.sh PROVIDED. USING DEFAULT TEMPLATE."
-  cp /usr/local/spark/2.1.0/conf/spark-env.sh.template /usr/local/spark/2.1.0/conf/spark-env.sh
+  cp /usr/local/spark/2.3.4/conf/spark-env.sh.template /usr/local/spark/2.3.4/conf/spark-env.sh
 fi
 
 # Create Zeppelin conf
@@ -79,8 +79,11 @@ then
   fi
 else
   echo "WARNING: no spark-default.conf provided. Using default in-memory Spark."
-  unset SPARK_HOME
+  echo "Use SPARK_HOME=$SPARK_HOME"
+  echo "export SPARK_HOME=$SPARK_HOME" >> /zeppelin/conf/zeppelin-env.sh
 fi
+
+
 
 # Run another script to upgrade Spark interpreter config after Zeppelin boot
 /zeppelin/saagie-zeppelin-config.sh &

--- a/saagie-zeppelin.sh
+++ b/saagie-zeppelin.sh
@@ -54,14 +54,14 @@ fi
 # before running Zepplin
 if [ -f "/usr/local/spark/conf/spark-env.sh" ]
 then
-  # overwrite Spark 2.3.4 config
+  # overwrite Spark config
   echo "INFO: ovewriting default spark-env.sh"
-  cp /usr/local/spark/conf/spark-env.sh /usr/local/spark/2.3.4/conf
-  chmod 755 /usr/local/spark/2.3.4/conf/spark-env.sh
+  cp /usr/local/spark/conf/spark-env.sh /usr/local/spark/${SPARK_VERSION}/conf
+  chmod 755 /usr/local/spark/${SPARK_VERSION}/conf/spark-env.sh
 else
   # use default config
   echo "WARNING: NO CUSTOM spark-env.sh PROVIDED. USING DEFAULT TEMPLATE."
-  cp /usr/local/spark/2.3.4/conf/spark-env.sh.template /usr/local/spark/2.3.4/conf/spark-env.sh
+  cp /usr/local/spark/${SPARK_VERSION}/conf/spark-env.sh.template /usr/local/spark/${SPARK_VERSION}/conf/spark-env.sh
 fi
 
 # Create Zeppelin conf


### PR DESCRIPTION
Use latest zeppelin image as base
Use latest spark2.4.5 release as well

Use a turnaround because of : https://issues.apache.org/jira/browse/ZEPPELIN-4783
until PR : https://github.com/apache/zeppelin/pull/3755 is merged